### PR TITLE
Add handling of cases when an expanded command was derived from multiple aliases

### DIFF
--- a/def-matcher.go
+++ b/def-matcher.go
@@ -53,13 +53,34 @@ func MatchDef(defs []Def, command string) *Def {
 		return len(defs[j].abbr) <= len(defs[i].abbr)
 	})
 
-	for _, def := range defs {
-		if strings.HasPrefix(command, def.abbr) {
-			return &def
+	var candidate Def
+
+	for true {
+		var match Def
+		for _, def := range defs {
+
+			if command == def.abbr {
+				match = def
+				break
+			} else if strings.HasPrefix(command, def.abbr) {
+				match = def
+				break
+			}
+		}
+
+		if match != (Def{}) {
+			command = fmt.Sprintf("%s%s", match.alias, command[len(match.abbr):])
+			candidate = match
+		} else {
+			break
 		}
 	}
 
-	return nil
+	if candidate != (Def{}) {
+		return &candidate
+	} else {
+		return nil
+	}
 }
 
 func main() {

--- a/def-matcher_test.go
+++ b/def-matcher_test.go
@@ -69,6 +69,14 @@ func TestMatchDef(t *testing.T) {
 			alias: "gcb",
 			abbr:  "git checkout -b",
 		},
+		{
+			alias: "ls",
+			abbr:  "ls -G",
+		},
+		{
+			alias: "ll",
+			abbr:  "ls -lh",
+		},
 	}
 
 	mockArgs := []struct {
@@ -95,6 +103,11 @@ func TestMatchDef(t *testing.T) {
 			subject:  "when it has no matches, then return a empty string",
 			command:  "cd ..",
 			expected: nil,
+		},
+		{
+			subject:  "when it was expanded recursively from >1 aliases, then reduce it fully",
+			command:  "ls -G -lh", // ll expands to that with ls='ls -G' and ll='ls -lh' aliases defined
+			expected: &Def{alias: "ll"},
 		},
 	}
 


### PR DESCRIPTION
Hi there,

I've encountered a really strange behaviour with my alias set:
```00:13:31 ~ ➜ mkdir fast-alias-tips-test
00:13:37 ~ ➜ cd fast-alias-tips-test
00:13:52 ~/fast-alias-tips-test ➜ alias | grep ls  
l='ls -lah'  
la='ls -lAh'  
ll='ls -lh'  <--------| perpetrators
ls='ls -G'   <--------|
lsa='ls -lah'    
00:14:08 ~/fast-alias-tips-test ➜ touch q  
00:14:15 ~/fast-alias-tips-test ➜ ls -lh  <---- ls is an alias, but there's ll='ls -lh'
total 0                                   <---- no suggestion
-rw-r--r--  1 afetisov  staff     0B Mar 14 00:14 q  
00:14:33 ~/fast-alias-tips-test ➜ ll <--------- an alias
💡 ls -lh                            <--------- a suggestion
total 0  
-rw-r--r--  1 afetisov  staff     0B Mar 14 00:14 q  
```

The problem was caused by the fact, that `ls -lh` command was expanded to `ls -G -lh` and that was piped to the executable. `MatchDef` function was able to find a corresponding entry (`ls -G`) using `strings.HasPrefix(command, def.abbr)`, returned plain `ls` as a match and just added unrecognized parameter `-lh` to the final output. The resulted suggestion was exactly the same as the original command, so no suggestion was shown.
`ll`, on the other hand, was expanded twice: first to `ls -lh` and then to `ls -G -lh`, resulting in the same input to the executable. Output was also the same, but, since it was different from the original command, the suggestion was displayed (not very helpful, though).

With a new search strategy, which iteratively updates command and tries to reduce the command to the shortest form possible, that shouldn't be a problem anymore.