### PR TITLE
build: build for Apple Silicon

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -7,11 +7,11 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     container:
-      image: golang:1.11
+      image: golang:1.16
     steps:
       - uses: actions/checkout@v2
 
       - name: 'Run GoReleaser'
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
 release:
   github:


### PR DESCRIPTION
Use [Go v1.16](https://go.dev/doc/go1.16) which has support for `Darwin/arm64`.
Add `arm64` arch for release.
Use `goreleaser/goreleaser-action@v2`

_Reasoning:_
When running on an M1 Mac (arm64) **without** Rosetta 2 installed, the following error is thrown:
```sh
__fast_alias_tips_preexec:6: bad CPU type in executable: def-matcher
```
